### PR TITLE
Fix proptype error for boolean

### DIFF
--- a/src/components/Navbar/NavLinks.js
+++ b/src/components/Navbar/NavLinks.js
@@ -97,6 +97,6 @@ NavLinks.propTypes = {
   completed: PropTypes.object,
   handleClick: PropTypes.func,
   innerClassName: PropTypes.string,
-  outerClassName: PropTypes.bool,
+  outerClassName: PropTypes.string,
   setExample: PropTypes.func,
 }


### PR DESCRIPTION
Hotfix on PropType error

Before:
<img width="497" alt="Screen Shot 2021-06-30 at 10 04 12 AM" src="https://user-images.githubusercontent.com/25035900/123977575-1a500500-d98d-11eb-93e5-b3dd6f39ed30.png">

After:
<img width="490" alt="Screen Shot 2021-06-30 at 10 22 48 AM" src="https://user-images.githubusercontent.com/25035900/123977613-250a9a00-d98d-11eb-8f1c-ecabeeaed7fd.png">

Note: Other errors shown in the screen captures are related to lessons.
